### PR TITLE
[Technical-Support] AUI-1893 Wrong display of recurrent overnight events in week view in the last day of first week under DST

### DIFF
--- a/src/aui-scheduler/HISTORY.md
+++ b/src/aui-scheduler/HISTORY.md
@@ -4,6 +4,7 @@
 
 ## @VERSION@
 
+* [AUI-1893](https://issues.liferay.com/browse/AUI-1893) Wrong display of recurrent overnight events in week view in the last day of first week under DST
 * [AUI-1880](https://issues.liferay.com/browse/AUI-1880) Overlapping events don't show up correctly
 * [AUI-1871](https://issues.liferay.com/browse/AUI-1871) In month view, popover does not update values if an event was previously displayed
 

--- a/src/aui-scheduler/js/aui-scheduler-view-day.js
+++ b/src/aui-scheduler/js/aui-scheduler-view-day.js
@@ -743,10 +743,18 @@ var SchedulerDayView = A.Component.create({
             var instance = this;
 
             var viewDate = DateMath.safeClearTime(
-                instance.get('scheduler').get('viewDate'));
+                instance.get('scheduler').get('viewDate')),
+                offsetDate = DateMath.safeClearTime(date),
+                d1Offset = viewDate.getTimezoneOffset(),
+                d2Offset = offsetDate.getTimezoneOffset();
 
-            return DateMath.getDayOffset(
-                DateMath.safeClearTime(date), viewDate);
+            if (d1Offset !== d2Offset) {
+                var difference = d1Offset - d2Offset;
+
+                offsetDate = new Date(offsetDate.getTime() + (difference * DateMath.ONE_MINUTE_MS));
+            }
+
+            return DateMath.getDayOffset(offsetDate, viewDate);
         },
 
         /**

--- a/src/aui-scheduler/tests/unit/js/tests.js
+++ b/src/aui-scheduler/tests/unit/js/tests.js
@@ -499,6 +499,62 @@ YUI.add('aui-scheduler-tests', function(Y) {
             );
         },
 
+        'should display events correctly in week view in the last day of first week under DST when first day of week is Monday': function() {
+            var column1,
+                column1Events,
+                column2,
+                column2Events,
+                schedulerEvents,
+                dstDate = this._getLocalTimeZoneDSTFirstDay(),
+                currentDate = DateMath.subtract(dstDate, DateMath.DAY, 1),
+                previousDate = DateMath.subtract(dstDate, DateMath.DAY, 2);
+
+            this._createScheduler({
+                activeView: this._weekView,
+                date: previousDate,
+                firstDayOfWeek: 1,
+                items: [
+                    {
+                        content: 'Event 1',
+                        startDate: DateMath.add(new Date(previousDate.getTime()), DateMath.HOUR, 23),
+                        endDate: DateMath.add(new Date(previousDate.getTime()), DateMath.HOUR, 25)
+                    },
+                    {
+                        content: 'Event 2',
+                        startDate: DateMath.add(new Date(currentDate.getTime()), DateMath.HOUR, 23),
+                        endDate: DateMath.add(new Date(currentDate.getTime()), DateMath.HOUR, 25)
+                    }
+                ]
+            });
+
+            schedulerEvents = Y.all('.scheduler-event');
+
+            Y.Assert.areEqual(
+                3, schedulerEvents.size(),
+                '3 SchedulerEvent nodes should be in week view.'
+            );
+
+            var columns = Y.all('.scheduler-view-day-table-colday');
+
+            column1 = columns.item(5);
+
+            column1Events = column1.all('.scheduler-event');
+
+            Y.Assert.areEqual(
+                1, column1Events.size(),
+                '1 SchedulerEvent node should be in column1Events column.'
+            );
+
+            column2 = columns.item(6);
+
+            column2Events = column2.all('.scheduler-event');
+
+            Y.Assert.areEqual(
+                2, column2Events.size(),
+                '2 SchedulerEvent nodes should be in column2Events column.'
+            );
+        },
+
         'should display overlapping events correctly in week view': function() {
             var column1,
                 column1Events,


### PR DESCRIPTION
Hi Maira,

We have again a new Scheduler issue :)

I documented this issue in AUI-1893 ticket. Please see my attached screens and my new test cases.

I had another idea regarding this fix. We could made a new method in DateMath which will be responsible for handle Date objects with different Timezones.

Thanks in advance,
 Zsaga